### PR TITLE
Better dependency version control

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,11 +24,11 @@ let package = Package(
     .package(
       name: "abseil",
       url: "https://github.com/firebase/abseil-cpp-SwiftPM.git",
-      from: "0.20200225.1"
+      "0.20200225.3" ..< "0.20200226.0"
     ),
     .package(name: "BoringSSL-GRPC",
       url: "https://github.com/firebase/boringssl-SwiftPM.git",
-      from: "0.0.8"
+      "0.7.1" ..< "0.8.0"
     ),
   ],
 


### PR DESCRIPTION
Don't allow unrestricted dependency version updates.  This has the potential to break users locked on older versions when a later version comes out.

Instead allow only patch upgrades.

For Boring SSL, switch the versioning mechanism to a translation of the unforked repo's patch version to the minor version so that the patch version can be used for SPM fixes. 